### PR TITLE
remove underscore from outneighbors/inneighbors

### DIFF
--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -12,7 +12,7 @@ import LightGraphs:
     AbstractGraph, src, dst, edgetype, nv,
     ne, vertices, edges, is_directed,
     add_vertex!, add_edge!, rem_vertex!, rem_edge!,
-    has_vertex, has_edge, in_neighbors, out_neighbors,
+    has_vertex, has_edge, inneighbors, outneighbors,
     weights, indegree, outdegree, degree,
     induced_subgraph,
     loadgraph, savegraph, AbstractGraphFormat
@@ -67,8 +67,8 @@ edges(g::AbstractMetaGraph) = edges(g.graph)
 has_vertex(g::AbstractMetaGraph, x...) = has_vertex(g.graph, x...)
 @inline has_edge(g::AbstractMetaGraph, x...) = has_edge(g.graph, x...)
 
-in_neighbors(g::AbstractMetaGraph, v::Integer) = in_neighbors(g.graph, v)
-out_neighbors(g::AbstractMetaGraph, v::Integer) = fadj(g.graph, v)
+inneighbors(g::AbstractMetaGraph, v::Integer) = inneighbors(g.graph, v)
+outneighbors(g::AbstractMetaGraph, v::Integer) = fadj(g.graph, v)
 
 issubset(g::T, h::T) where T<:AbstractMetaGraph = issubset(g.graph, h.graph)
 

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -47,7 +47,7 @@ importall MetaGraphs
 
         @test @inferred(vertices(mg)) == 1:4
         @test Edge(2,3) in edges(mg)
-        @test @inferred(out_neighbors(mg,2)) == in_neighbors(mg,2) == neighbors(mg,2)
+        @test @inferred(outneighbors(mg,2)) == inneighbors(mg,2) == neighbors(mg,2)
         @test @inferred(has_edge(mg, 2, 3))
         @test @inferred(has_edge(mg, 3, 2))
 
@@ -70,7 +70,7 @@ importall MetaGraphs
         @test @inferred(!rem_vertex!(mga, 10))
 
         @test @inferred(zero(mg)) == MetaGraph{eltype(mg), weighttype(mg)}()
-        @test @inferred(eltype(mg)) == eltype(out_neighbors(mg, 1)) == eltype(nv(mg))
+        @test @inferred(eltype(mg)) == eltype(outneighbors(mg, 1)) == eltype(nv(mg))
         T = @inferred(eltype(mg))
         U = @inferred(weighttype(mg))
         @test @inferred(nv(MetaGraph{T, U}(6))) == 6
@@ -104,8 +104,8 @@ importall MetaGraphs
 
         @test @inferred(vertices(mg)) == 1:4
         @test Edge(2,3) in edges(mg)
-        @test @inferred(out_neighbors(mg,2)) == [3]
-        @test @inferred(in_neighbors(mg,2)) == [1]
+        @test @inferred(outneighbors(mg,2)) == [3]
+        @test @inferred(inneighbors(mg,2)) == [1]
         @test @inferred(has_edge(mg, 2, 3))
         @test @inferred(!has_edge(mg, 3, 2))
 
@@ -128,7 +128,7 @@ importall MetaGraphs
         @test @inferred(!rem_vertex!(mga, 10))
 
         @test @inferred(zero(mg)) == MetaDiGraph{eltype(mg), weighttype(mg)}()
-        @test @inferred(eltype(mg)) == eltype(out_neighbors(mg, 1)) == eltype(nv(mg))
+        @test @inferred(eltype(mg)) == eltype(outneighbors(mg, 1)) == eltype(nv(mg))
         T = @inferred(eltype(mg))
         U = @inferred(weighttype(mg))
         @test @inferred(nv(MetaDiGraph{T, U}(6))) == 6


### PR DESCRIPTION
This will be necessary once we tag the new version of LG.