### PR TITLE
Fix/#32

### DIFF
--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -130,7 +130,7 @@ function rem_vertex!(g::AbstractMetaGraph, v::Integer)
     v in vertices(g) || return false
     lastv = nv(g)
     lastvprops = props(g, lastv)
-    
+
     lasteoutprops = Dict(n => props(g, lastv, n) for n in outneighbors(g, lastv))
     lasteinprops = Dict(n => props(g, n, lastv) for n in inneighbors(g, lastv))
     clear_props!(g, v)
@@ -156,7 +156,7 @@ function rem_vertex!(g::AbstractMetaGraph, v::Integer)
         for n in outneighbors(g, v)
             set_props!(g, v, n, lasteoutprops[n])
         end
-        
+
         for n in inneighbors(g, v)
             set_props!(g, n, v, lasteinprops[n])
         end
@@ -360,7 +360,12 @@ function set_indexing_prop!(g::AbstractMetaGraph, v::Integer, prop::Symbol, val:
     (haskey(g.metaindex[prop], val) && g.vprops[v][prop] == val) && return g.indices
     haskey(g.metaindex[prop], val) && error("':$prop' index already contains $val")
 
-    delete!(g.metaindex[prop], g.vprops[v][prop])
+    if !haskey(g.vprops, v)
+        push!(g.vprops, v=>Dict{Symbol,Any}())
+    end
+    if haskey(g.vprops[v], :prop)
+        delete!(g.metaindex[prop], g.vprops[v][prop])
+    end
     g.metaindex[prop][val] = v
     g.vprops[v][prop] = val
     return g.indices

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -350,7 +350,18 @@ importall MetaGraphs
     @test ne(mga) == 1
     @test length(mga.eprops) == 1 # should only be edge 3=>2
     @test props(mga, 3, 2)[:name] == "3, 4"
-    
+
+    # test for #32
+    mga = MetaGraph(PathGraph(4))
+    for j in 1:4
+        set_prop!(mga, j, :prop, "node$j")
+    end
+    set_indexing_prop!(mga, :prop)
+    add_vertex!(mga)
+    set_indexing_prop!(mga, nv(mga), :prop, "node5")
+    @test mga["node5", :prop] == 5
+    @test get_prop(mga, 5, :prop) == "node5"
+
     # test for #33
     mga = MetaGraph(PathGraph(4))
     set_prop!(mga, 1, 2, :name, "1, 2")
@@ -365,7 +376,7 @@ importall MetaGraphs
     @test has_prop(mga, 3, :v)
 
 
-    
+
 
 end
 
@@ -444,5 +455,3 @@ end
     @test weightfield(rmg) == weightfield(mga) == :weight
     @test defaultweight(rmg) == defaultweight(mga) == 8
 end
-
-


### PR DESCRIPTION
This ought to fix https://github.com/JuliaGraphs/MetaGraphs.jl/issues/32

It passes the same tests on Julia 0.7 as before. Unit test for the specific issue added and passes. 

Now you can issue
`set_indexing_prop!(g, vert, :prop, val)` even if `vert` doesn't already have property `prop`.