### PR TITLE
Fixes fix#32; setting index via set_prop! now possible.

### DIFF
--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -287,11 +287,12 @@ edge `e` (optionally referenced by source vertex `s` and destination vertex `d`)
 Will return false if vertex or edge does not exist, true otherwise
 """
 set_prop!(g::AbstractMetaGraph, prop::Symbol, val) = set_props!(g, Dict(prop => val))
-set_prop!(g::AbstractMetaGraph, v::Integer, prop::Symbol, val) =
+set_prop!(g::AbstractMetaGraph, v::Integer, prop::Symbol, val) = begin
     if in(prop, g.indices)
-    error("':$prop' is an indexing property, use `set_indexing_prop!()` instead")
-else
-    set_props!(g, v, Dict(prop => val))
+        set_indexing_prop!(g, v, prop, val)
+    else
+        set_props!(g, v, Dict(prop => val))
+    end
 end
 set_prop!(g::AbstractMetaGraph, e::SimpleEdge, prop::Symbol, val) = set_props!(g, e, Dict(prop => val))
 
@@ -357,13 +358,13 @@ end
 
 function set_indexing_prop!(g::AbstractMetaGraph, v::Integer, prop::Symbol, val::Any)
     !in(prop, g.indices) && set_indexing_prop!(g, prop, exclude=val)
-    (haskey(g.metaindex[prop], val) && g.vprops[v][prop] == val) && return g.indices
+    (haskey(g.metaindex[prop], val) && haskey(g.vprops, v) && haskey(g.vprops[v], prop) && g.vprops[v][prop] == val) && return g.indices
     haskey(g.metaindex[prop], val) && error("':$prop' index already contains $val")
 
     if !haskey(g.vprops, v)
         push!(g.vprops, v=>Dict{Symbol,Any}())
     end
-    if haskey(g.vprops[v], :prop)
+    if haskey(g.vprops[v], prop)
         delete!(g.metaindex[prop], g.vprops[v][prop])
     end
     g.metaindex[prop][val] = v

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -375,7 +375,18 @@ importall MetaGraphs
     @test !has_prop(mga, 4, :v)
     @test has_prop(mga, 3, :v)
 
-
+    # test for setting indexed props with set_prop!
+    mga = MetaGraph(PathGraph(4))
+    for j in 1:3
+        set_indexing_prop!(mga, j, :prop, "node$j")
+    end
+    add_vertex!(mga)
+    set_prop!(mga, nv(mga), :prop, "node5")
+    set_prop!(mga, 1, :prop, "newnode1")
+    @test get_prop(mga, 4, :prop) == "prop4"
+    @test mga["node5", :prop] == 5
+    @test get_prop(mga, 5, :prop) == "node5"
+    @test get_prop(mga, 1, :prop) == "newnode1"
 
 
 end
@@ -404,8 +415,8 @@ end
 
     @test_throws ErrorException set_indexing_prop!(G, 4, :name, "gnode_3")
     @test_throws ErrorException set_indexing_prop!(dG, 4, :name, "dgnode_3")
-    @test_throws ErrorException set_prop!(G, 3, :name, "name3")
-    @test_throws ErrorException set_prop!(dG, 3, :name, "name3")
+    @test_throws ErrorException set_prop!(G, 4, :name, "gnode_3")
+    @test_throws ErrorException set_prop!(dG, 4, :name, "dgnode_3")
     @test_throws ErrorException set_props!(G, 5, Dict(:name => "name", :other_name => "something"))
     @test_throws ErrorException set_props!(dG, 5, Dict(:name => "name", :other_name => "something"))
 


### PR DESCRIPTION
1. `set_prop!(g, v, prop, val)` calls `set_indexing_prop!(g, v, prop, val)` if `prop` is an index.
2. https://github.com/JuliaGraphs/MetaGraphs.jl/pull/44#discussion_r211541593 introduced a bug through which `metaindex` wasn't properly set when calling `set_indexing_prop!` on a non-existing property.


