### PR TITLE
All tests pass on julia-0.7

### DIFF
--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -8,6 +8,8 @@ import Base:
     Tuple, copy, length, size,
     start, next, done, issubset,
     zero, getindex
+import Random:
+    randstring, seed!
 
 import LightGraphs:
     AbstractGraph, src, dst, edgetype, nv,
@@ -322,9 +324,9 @@ Provides a default index value for a vertex if no value currently exists. The de
 function default_index_value(v::Integer, prop::Symbol, index_values::Set{Any}; exclude=nothing)
     val = string(prop) * string(v)
     if in(val, index_values) || val == exclude
-        srand(v + hash(prop))
+        seed!(v + hash(prop))
         val = randstring()
-        warn("'$(string(prop))$v' is already in index, setting ':$prop' for vertex $v to $val")
+        @warn("'$(string(prop))$v' is already in index, setting ':$prop' for vertex $v to $val")
     end
     return val
 end

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -1,4 +1,7 @@
-importall MetaGraphs
+using MetaGraphs
+import LightGraphs: SimpleGraphs
+import Base64:
+        stringmime
 
 
 @testset "MetaGraphs" begin
@@ -146,7 +149,7 @@ importall MetaGraphs
         T = eltype(mg)
         U = weighttype(mg)
         @test sprint(show, mg) == "{0, 0} undirected $T metagraph with $U weights defined by :$(mg.weightfield) (default weight $(mg.defaultweight))"
-        @test @inferred(add_vertices!(g, 5)) == 5
+        @test @inferred(add_vertices!(mg, 5)) == 5
         @test sprint(show, mg) == "{5, 0} undirected $T metagraph with $U weights defined by :$(mg.weightfield) (default weight $(mg.defaultweight))"
     end
     gx = SimpleDiGraph()
@@ -420,7 +423,7 @@ end
     @test_throws ErrorException set_props!(G, 5, Dict(:name => "name", :other_name => "something"))
     @test_throws ErrorException set_props!(dG, 5, Dict(:name => "name", :other_name => "something"))
 
-    info("Ignore \"'foo1' is already in index\" warnings")
+    @info("Ignore \"'foo1' is already in index\" warnings")
     set_indexing_prop!(G, 50, :name, "another name")
     set_indexing_prop!(G, 50, :name, "another name")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using LightGraphs
 using MetaGraphs
-using Base.Test
+using Test
 
 import LightGraphs.SimpleGraphs: SimpleGraph, SimpleDiGraph
 testdir = dirname(@__FILE__)


### PR DESCRIPTION
Remaining warnings are due to missing constructor in `LightGraphs`. All tests will pass on Julia 1.0 when https://github.com/JuliaGraphs/LightGraphs.jl/issues/997 is taken care of.

