### PR TITLE
Possible fix for #60 -- change the prop of both directions of each edge

### DIFF
--- a/src/metagraph.jl
+++ b/src/metagraph.jl
@@ -60,16 +60,17 @@ function props(g::MetaGraph, _e::SimpleEdge)
 end
 
 function set_props!(g::MetaGraph, _e::SimpleEdge, d::Dict)
-    e = LightGraphs.is_ordered(_e) ? _e : reverse(_e)
-    if has_edge(g, e)
+    _e_reverse = reverse(_e)
+    (!has_edge(g, _e) || !has_edge(g, _e_reverse)) && return false
+
+    for e in (_e, _e_reverse)
         if !_hasdict(g, e)
             g.eprops[e] = d
         else
             merge!(g.eprops[e], d)
         end
-        return true
     end
-    return false
+    return true
 end
 
 zero(g::MetaGraph{T,U}) where T where U = MetaGraph{T,U}(SimpleGraph{T}())

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -181,7 +181,6 @@ import Base64:
     add_edge!(mdg60, 1, 2)
     add_edge!(mdg60, 2, 1)
     set_prop!(mdg60, 2, 1, :weight, 7.0)
-    # @test get_prop(mdg60, 1, 2, :weight) == 1.0  # broken? Should it display the defaultweight?
     @test get_prop(mdg60, 2, 1, :weight) == 7.0
     @test weights(mdg60)[1, 2] == 1.0
     @test weights(mdg60)[2, 1] == 7.0

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -169,6 +169,23 @@ import Base64:
     @test set_prop!(mg, 2, 3, :weight, 1)
     @test enumerate_paths(dijkstra_shortest_paths(mg, 1), 3) == [1, 2, 3]
 
+    # issue #60
+    mg60 = MetaGraph(2)
+    add_edge!(mg60, 1, 2)
+    set_prop!(mg60, 2, 1, :weight, 7.0)
+    @test get_prop(mg60, 1, 2, :weight) == 7.0
+    @test get_prop(mg60, 2, 1, :weight) == 7.0
+    @test weights(mg60)[1, 2] == 7.0
+    @test_broken weights(mg60)[2, 1] == 7.0
+    mdg60 = MetaDiGraph(2)
+    add_edge!(mdg60, 1, 2)
+    add_edge!(mdg60, 2, 1)
+    set_prop!(mdg60, 2, 1, :weight, 7.0)
+    # @test get_prop(mdg60, 1, 2, :weight) == 1.0  # broken? Should it display the defaultweight?
+    @test get_prop(mdg60, 2, 1, :weight) == 7.0
+    @test weights(mdg60)[1, 2] == 1.0
+    @test weights(mdg60)[2, 1] == 7.0
+
     @test set_prop!(mg, 1, :color, "blue")
     @test set_prop!(mg, 1, :color, "blue")
     @test !set_prop!(mg, 1000, :color, "blue") # nonexistent vertex

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -176,7 +176,7 @@ import Base64:
     @test get_prop(mg60, 1, 2, :weight) == 7.0
     @test get_prop(mg60, 2, 1, :weight) == 7.0
     @test weights(mg60)[1, 2] == 7.0
-    @test_broken weights(mg60)[2, 1] == 7.0
+    @test weights(mg60)[2, 1] == 7.0
     mdg60 = MetaDiGraph(2)
     add_edge!(mdg60, 1, 2)
     add_edge!(mdg60, 2, 1)
@@ -366,7 +366,7 @@ import Base64:
     @test rem_vertex!(mga, 2)
     @test nv(mga) == 3
     @test ne(mga) == 1
-    @test length(mga.eprops) == 1  # should only be edge 2=>3
+    @test length(mga.eprops) == 2  # edges 2=>3 and 3=>2
     @test props(mga, 2, 3)[:name] == "3, 4"
 
     mga = MetaDiGraph(PathDiGraph(4))


### PR DESCRIPTION
Since `getindex` of `MetaWeights` looks for a directed Edge, this change lets `set_props!` set the value for both directions.

This means a test needed to be changed because this altered the very value that was changed against.

Pros:
- Solves the problem at its core, whenever a value of an undirected graph is looked up with a directed Edge, it should still return the right value (future-proof).

Cons:
- If there is some behavior that depends on there being only one `prop` instead of two, it is going to be broken. I assume that is going to be unlikely though.
- The time needed for `set_prop` increases form ~400ns to ~600ns on my machine.