### PR TITLE
Possible fix for #60 -- field directed for MetaWeights

### DIFF
--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -174,7 +174,7 @@ end
 show(io::IO, x::MetaWeights) = print(io, "metaweights")
 show(io::IO, z::MIME"text/plain", x::MetaWeights) = show(io, x)
 
-MetaWeights(g::AbstractMetaGraph) = MetaWeights{eltype(g),eltype(g.defaultweight)}(nv(g), g.weightfield, g.defaultweight, g.eprops, true)
+MetaWeights(g::AbstractMetaGraph) = MetaWeights{eltype(g),eltype(g.defaultweight)}(nv(g), g.weightfield, g.defaultweight, g.eprops, is_directed(g))
 
 function getindex(w::MetaWeights{T,U}, u::Integer, v::Integer)::U where T <: Integer where U <: Real
     _e = Edge(u, v)

--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -169,14 +169,16 @@ struct MetaWeights{T <: Integer,U <: Real} <: AbstractMatrix{U}
     weightfield::Symbol
     defaultweight::U
     eprops::Dict{SimpleEdge{T},PropDict}
+    directed::Bool
 end
 show(io::IO, x::MetaWeights) = print(io, "metaweights")
 show(io::IO, z::MIME"text/plain", x::MetaWeights) = show(io, x)
 
-MetaWeights(g::AbstractMetaGraph) = MetaWeights{eltype(g),eltype(g.defaultweight)}(nv(g), g.weightfield, g.defaultweight, g.eprops)
+MetaWeights(g::AbstractMetaGraph) = MetaWeights{eltype(g),eltype(g.defaultweight)}(nv(g), g.weightfield, g.defaultweight, g.eprops, true)
 
 function getindex(w::MetaWeights{T,U}, u::Integer, v::Integer)::U where T <: Integer where U <: Real
-    e = Edge(u, v)
+    _e = Edge(u, v)
+    e = !w.directed && !LightGraphs.is_ordered(_e) ? reverse(_e) : _e
     !haskey(w.eprops, e) && return w.defaultweight
     return U(get(w.eprops[e], w.weightfield, w.defaultweight))
 end

--- a/src/metagraph.jl
+++ b/src/metagraph.jl
@@ -59,6 +59,8 @@ function props(g::MetaGraph, _e::SimpleEdge)
     get(g.eprops, e, PropDict())
 end
 
+MetaWeights(g::MetaGraph) = MetaWeights{eltype(g),eltype(g.defaultweight)}(nv(g), g.weightfield, g.defaultweight, g.eprops, false)
+
 function set_props!(g::MetaGraph, _e::SimpleEdge, d::Dict)
     e = LightGraphs.is_ordered(_e) ? _e : reverse(_e)
     if has_edge(g, e)

--- a/src/metagraph.jl
+++ b/src/metagraph.jl
@@ -59,8 +59,6 @@ function props(g::MetaGraph, _e::SimpleEdge)
     get(g.eprops, e, PropDict())
 end
 
-MetaWeights(g::MetaGraph) = MetaWeights{eltype(g),eltype(g.defaultweight)}(nv(g), g.weightfield, g.defaultweight, g.eprops, false)
-
 function set_props!(g::MetaGraph, _e::SimpleEdge, d::Dict)
     e = LightGraphs.is_ordered(_e) ? _e : reverse(_e)
     if has_edge(g, e)

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -181,7 +181,6 @@ import Base64:
     add_edge!(mdg60, 1, 2)
     add_edge!(mdg60, 2, 1)
     set_prop!(mdg60, 2, 1, :weight, 7.0)
-    # @test get_prop(mdg60, 1, 2, :weight) == 1.0  # broken? Should it display the defaultweight?
     @test get_prop(mdg60, 2, 1, :weight) == 7.0
     @test weights(mdg60)[1, 2] == 1.0
     @test weights(mdg60)[2, 1] == 7.0

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -169,6 +169,23 @@ import Base64:
     @test set_prop!(mg, 2, 3, :weight, 1)
     @test enumerate_paths(dijkstra_shortest_paths(mg, 1), 3) == [1, 2, 3]
 
+    # issue #60
+    mg60 = MetaGraph(2)
+    add_edge!(mg60, 1, 2)
+    set_prop!(mg60, 2, 1, :weight, 7.0)
+    @test get_prop(mg60, 1, 2, :weight) == 7.0
+    @test get_prop(mg60, 2, 1, :weight) == 7.0
+    @test weights(mg60)[1, 2] == 7.0
+    @test_broken weights(mg60)[2, 1] == 7.0
+    mdg60 = MetaDiGraph(2)
+    add_edge!(mdg60, 1, 2)
+    add_edge!(mdg60, 2, 1)
+    set_prop!(mdg60, 2, 1, :weight, 7.0)
+    # @test get_prop(mdg60, 1, 2, :weight) == 1.0  # broken? Should it display the defaultweight?
+    @test get_prop(mdg60, 2, 1, :weight) == 7.0
+    @test weights(mdg60)[1, 2] == 1.0
+    @test weights(mdg60)[2, 1] == 7.0
+
     @test set_prop!(mg, 1, :color, "blue")
     @test set_prop!(mg, 1, :color, "blue")
     @test !set_prop!(mg, 1000, :color, "blue") # nonexistent vertex

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -176,7 +176,7 @@ import Base64:
     @test get_prop(mg60, 1, 2, :weight) == 7.0
     @test get_prop(mg60, 2, 1, :weight) == 7.0
     @test weights(mg60)[1, 2] == 7.0
-    @test_broken weights(mg60)[2, 1] == 7.0
+    @test weights(mg60)[2, 1] == 7.0
     mdg60 = MetaDiGraph(2)
     add_edge!(mdg60, 1, 2)
     add_edge!(mdg60, 2, 1)


### PR DESCRIPTION
Since the props of undirected graphs are only stored for one of the two edges (lower => higher), get the weight also from that edge if the graph is undirected.

Because `MetaWeights` has no connection to the graph it came from, I added the `directed` field. This name stemmed from the original idea to use
```MetaWeights(g::AbstractMetaGraph) = MetaWeights{eltype(g),eltype(g.defaultweight)}(nv(g), g.weightfield, g.defaultweight, g.eprops, is_directed(g))```
Because I don't think `is_directed` is necessarily defined for all `AbstractMetaGraph`s, I went for the route to give `directed` a default value of `true` (to get the current behavior by default) and add an extra constructor for the undirected version. That field should get a more descriptive name.

Pros:
- No preformance regression (that I could find)
- Unontrusive: since the field didn't exist before and the default behavior isn't changed, this fix can't break anything

Cons:
- Fixes the issue only with regard to `weights`. If something else doesn't check if the graph is directed or undirected, it might run into the same issue again.
- Any new undirected graph needs to add a fitting constructor to work properly. Maybe this can be fixed with some type magic I'm unaware of? 