### PR TITLE
Fix rem_vertex!

### DIFF
--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -157,12 +157,13 @@ function rem_vertex!(g::AbstractMetaGraph, v::Integer)
     clear_props!(g, lastv)
     retval = rem_vertex!(g.graph, v)
     if v != lastv # ignore if we're removing the last vertex.
-        retval || throw(DomainError("vertex could not be removed; graph is in an inconsistent state"))
-        for (key, val) in lastvprops
-            if (key in g.indices)
-                set_indexing_prop!(g, v, key, val)
-            else
-                set_prop!(g, v, key, val)
+        if retval
+            for (key, val) in lastvprops
+                if (key in g.indices)
+                    set_indexing_prop!(g, v, key, val)
+                else
+                    set_prop!(g, v, key, val)
+                end
             end
         end
         for n in outneighbors(g, v)

--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -134,6 +134,10 @@ function rem_vertex!(g::AbstractMetaGraph, v::Integer)
 
     lasteoutprops = Dict(n => props(g, lastv, n) for n in outneighbors(g, lastv))
     lasteinprops = Dict(n => props(g, n, lastv) for n in inneighbors(g, lastv))
+    for ind in g.indices
+        pop!(g.metaindex[ind],get_prop(g,lastv,ind))
+        v != lastv && pop!(g.metaindex[ind],get_prop(g,v,ind))
+    end
     clear_props!(g, v)
     for n in outneighbors(g, lastv)
         clear_props!(g, lastv, n)
@@ -152,8 +156,14 @@ function rem_vertex!(g::AbstractMetaGraph, v::Integer)
     end
     clear_props!(g, lastv)
     retval = rem_vertex!(g.graph, v)
-    retval && set_props!(g, v, lastvprops)
     if v != lastv # ignore if we're removing the last vertex.
+        for (key,val) in lastvprops
+            if (key in g.indices)
+                set_indexing_prop!(g,v,key,val)
+            else
+                retval && set_prop!(g,v,key,val)
+            end
+        end
         for n in outneighbors(g, v)
             set_props!(g, v, n, lasteoutprops[n])
         end

--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -135,8 +135,8 @@ function rem_vertex!(g::AbstractMetaGraph, v::Integer)
     lasteoutprops = Dict(n => props(g, lastv, n) for n in outneighbors(g, lastv))
     lasteinprops = Dict(n => props(g, n, lastv) for n in inneighbors(g, lastv))
     for ind in g.indices
-        pop!(g.metaindex[ind],get_prop(g,lastv,ind))
-        v != lastv && pop!(g.metaindex[ind],get_prop(g,v,ind))
+        pop!(g.metaindex[ind], get_prop(g, lastv, ind))
+        v != lastv && pop!(g.metaindex[ind], get_prop(g, v, ind))
     end
     clear_props!(g, v)
     for n in outneighbors(g, lastv)
@@ -157,11 +157,11 @@ function rem_vertex!(g::AbstractMetaGraph, v::Integer)
     clear_props!(g, lastv)
     retval = rem_vertex!(g.graph, v)
     if v != lastv # ignore if we're removing the last vertex.
-        for (key,val) in lastvprops
+        for (key, val) in lastvprops
             if (key in g.indices)
-                set_indexing_prop!(g,v,key,val)
+                retval && set_indexing_prop!(g, v, key, val)
             else
-                retval && set_prop!(g,v,key,val)
+                retval && set_prop!(g, v, key, val)
             end
         end
         for n in outneighbors(g, v)

--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -156,14 +156,13 @@ function rem_vertex!(g::AbstractMetaGraph, v::Integer)
     end
     clear_props!(g, lastv)
     retval = rem_vertex!(g.graph, v)
+    retval || return false
     if v != lastv # ignore if we're removing the last vertex.
-        if retval
-            for (key, val) in lastvprops
-                if (key in g.indices)
-                    set_indexing_prop!(g, v, key, val)
-                else
-                    set_prop!(g, v, key, val)
-                end
+        for (key, val) in lastvprops
+            if key in g.indices
+                set_indexing_prop!(g, v, key, val)
+            else
+                set_prop!(g, v, key, val)
             end
         end
         for n in outneighbors(g, v)
@@ -174,7 +173,7 @@ function rem_vertex!(g::AbstractMetaGraph, v::Integer)
             set_props!(g, n, v, lasteinprops[n])
         end
     end
-    return retval
+    return true
 end
 
 struct MetaWeights{T <: Integer,U <: Real} <: AbstractMatrix{U}

--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -157,11 +157,12 @@ function rem_vertex!(g::AbstractMetaGraph, v::Integer)
     clear_props!(g, lastv)
     retval = rem_vertex!(g.graph, v)
     if v != lastv # ignore if we're removing the last vertex.
+        retval || throw(DomainError("vertex could not be removed; graph is in an inconsistent state"))
         for (key, val) in lastvprops
             if (key in g.indices)
-                retval && set_indexing_prop!(g, v, key, val)
+                set_indexing_prop!(g, v, key, val)
             else
-                retval && set_prop!(g, v, key, val)
+                set_prop!(g, v, key, val)
             end
         end
         for n in outneighbors(g, v)

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -352,10 +352,12 @@ import Base64:
     for v in vertices(mga)
         set_prop!(mga, v, :name, string(v))
     end
+    set_indexing_prop!(mga,:name)
     @test get_prop(mga, 1, :name) == "1"
     @test get_prop(mga, 5, :name) == "5"
     @test rem_vertex!(mga, 1)
     @test get_prop(mga, 1, :name) == "5"
+    @test mga["5",:name] == 1
     @test isempty(props(mga, 5))
 
     # test for #22
@@ -476,4 +478,3 @@ end
     @test_throws ErrorException G[:not_a_key]
     @test_throws ErrorException dG[:not_a_key]
 end
-


### PR DESCRIPTION
Addressing #72 

A MetaGraph with an indexing property is not allowed to use `set_props!`  The metaindex must be handled separately.  Added test to check that an index_prop is handled correctly after `rem_vertex!`