### PR TITLE
Add the `haskey` method

### DIFF
--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -205,10 +205,14 @@ function getindex(g::AbstractMetaGraph, prop::Symbol)
 end
 
 function getindex(g::AbstractMetaGraph, indx::Any, prop::Symbol)
+    !haskey(g, indx, prop) && error("No node with prop $prop and key $indx")
+    return g.metaindex[prop][indx]
+end
+
+function Base.haskey(g::AbstractMetaGraph, indx::Any, prop::Symbol)
     haskey(g.metaindex, prop) || error("':$prop' is not an index")
     typeof(indx) <: eltype(keys(g.metaindex[prop])) || error("Index type does not match keys of metaindex '$prop'")
-    !haskey(g.metaindex[prop], indx) && error("No node with prop $prop and key $indx")
-    return g.metaindex[prop][indx]
+    return haskey(g.metaindex[prop], indx)
 end
 
 function getindex(g::AbstractMetaGraph, indx::Integer, prop::Symbol)


### PR DESCRIPTION
This pull request adds the `haskey` method with the signature `haskey(g::AbstractMetaGraph, indx::Any, prop::Symbol)`.

It also refactors the `getindex` method to use this new `haskey` method.

### Motivation

Sometimes I want to check if a graph has a given node, but I don't actually want to retrieve that node. This `haskey` method allows me to do so.

cc: @sbromberger 