### PR TITLE
Mention MetaDiGraphs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ julia> g = path_graph(5)
 julia> mg = MetaGraph(g, 3.0)
 {5, 4} undirected Int64 metagraph with Float64 weights defined by :weight (default weight 3.0)
 
+# create a directed metagraph based on the simplegraph, with optional default edgeweight
+julia> mdg = MetaDiGraph(g, 3.0)
+{5, 8} directed Int64 metagraph with Float64 weights defined by :weight (default weight 3.0)
+
 # set some properties for the graph itself
 julia> set_prop!(mg, :description, "This is a metagraph.")
 Dict{Symbol,Any} with 1 entry:


### PR DESCRIPTION
Adds a mention of MetaDiGraph in the README. I couldn't figure out how to better expose this functionality in the documentation, which seems to be autogenerated. Running `julia make.jl` gave:
```
ERROR: LoadError: MethodError: Cannot `convert` an object of type Symbol to an object of type Documenter.Writer
Closest candidates are:
  convert(::Type{T}, ::T) where T at essentials.jl:171
Stacktrace:
 [1] setindex!(::Array{Documenter.Writer,1}, ::Symbol, ::Int64) at ./array.jl:847
 [2] getindex at ./array.jl:414 [inlined]
 [3] Documenter.Documents.Document(::Tuple{}; root::String, source::String, build::String, workdir::Symbol, format::Symbol, clean::Bool, doctest::Bool, linkcheck::Bool, linkcheck_ignore::Array{Any,1}, linkcheck_timeout::Int64, checkdocs::Symbol, doctestfilters::Array{Regex,1}, strict::Bool, modules::Array{Module,1}, pages::Array{Any,1}, expandfirst::Array{String,1}, repo::String, sitename::String, authors::String, version::String, highlightsig::Bool, others::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/rick/.julia/packages/Documenter/FuXcO/src/Documents.jl:294
 [4] makedocs(; debug::Bool, format::Symbol, kwargs::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol,Symbol},NamedTuple{(:modules, :sitename, :pages),Tuple{Array{Module,1},String,Array{Any,1}}}}) at /home/rick/.julia/packages/Documenter/FuXcO/src/Documenter.jl:243
 [5] top-level scope at /home/rick/projects/contributing/MetaGraphs.jl/docs/make.jl:9
 [6] include(::Function, ::Module, ::String) at ./Base.jl:380
 [7] include(::Module, ::String) at ./Base.jl:368
 [8] exec_options(::Base.JLOptions) at ./client.jl:296
 [9] _start() at ./client.jl:506
in expression starting at /home/rick/projects/contributing/MetaGraphs.jl/docs/make.jl:9
```