### PR TITLE
Make LightGraphs min version 1.3.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,8 +8,8 @@ LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-JLD2 = "0.1.11, 0.2"
-LightGraphs = "1.2"
+JLD2 = "0.1.11, 0.2, 0.3"
+LightGraphs = "1.3.5"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
This is necessary because `hash` for edges is incorrectly implemented in
lower `LightGraphs` versions, so that `MetaGraphs` that have an eltype
different from `Int` do not correctly work. See: https://github.com/JuliaGraphs/LightGraphs.jl/pull/1514

Also add JLD2 version 0.3 to the allowed dependency versions.