### PR TITLE
Feature/dot output html label

### DIFF
--- a/src/persistence.jl
+++ b/src/persistence.jl
@@ -37,7 +37,12 @@ function savedot(io::IO, g::AbstractMetaGraph)
         end
         for p in props(g, v)
             key = p[1]
-            write(io, "$key=\"$(p[2])\",")
+            if  key .=== :label && occursin(r"<+.*>+$", p[2])
+                # The label is an HTML string, no additional quotes here.
+                write(io, "$key=$(p[2]),")
+            else
+                write(io, "$key=\"$(p[2])\",")
+            end
         end
         if length(props(g, v)) > 0
             write(io, "];")

--- a/test/diagram_ref.dot
+++ b/test/diagram_ref.dot
@@ -24,6 +24,7 @@ pack=true;
 22 [ color="#5DADE2",style="filled",penwidth="2.0",fillcolor="#dddddd",name="cases",label="Flu\nCases",shape="record",];
 23 [ color="#5DADE2",style="filled",penwidth="2.0",fillcolor="#dddddd",name="prices",label="Vacc\nPrice",shape="record",];
 24 [ color="#5DADE2",style="filled",penwidth="2.0",fillcolor="#dddddd",name="regres",label="Regression",shape="record",];
+25 [ color="#000000",style="filled",penwidth="2.0",fillcolor="#dddddd",name="html",label=<<U><B>Title </B></U> <BR/> Some text.>,shape="record",];
 1 -> 19 [ color=orange, dir=none, penwidth=4.0, style=solid, ]
 3 -> 15 [ color=orange, dir=none, penwidth=4.0, style=solid, ]
 3 -> 20 [ color=orange, dir=none, penwidth=4.0, style=solid, ]
@@ -51,4 +52,5 @@ pack=true;
 22 -> 24 [ color=orange, dir=none, penwidth=4.0, style=solid, ]
 23 -> 24 [ color=missing, dir=none, penwidth=missing, style=missing, ]
 24 -> 2 [ color=orange, dir=none, penwidth=4.0, style=solid, ]
+25 -> 4 [ color=black, dir=none, penwidth=2.0, style=solid, ]
 }


### PR DESCRIPTION
Hi @sbromberger ,

I've made some small tweaks in the DOT output to allow HTML-formatted "label" attributes. 
This allows (limited) formatting of nodes within DOT, which I happened to need for a project:

![test_output](https://user-images.githubusercontent.com/13941183/128045392-79cae8c4-e9d9-4ed5-914a-417829345a7a.png)

I've updated the test case accordingly.

Best regards, and thanks for the great package!