### PR TITLE
rem_vertex! bugfix

### DIFF
--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -169,6 +169,17 @@ function rem_vertex!(g::AbstractMetaGraph, v::Integer)
                 set_prop!(g, v, key, val)
             end
         end
+
+        # Map property keys to new node values
+        if lastv in keys(lasteoutprops)
+            lasteoutprops[v] = lasteoutprops[lastv]
+            delete!(lasteoutprops, lastv)
+        end
+        if lastv in keys(lasteinprops)
+            lasteinprops[v] = lasteinprops[lastv]
+            delete!(lasteinprops, lastv)
+        end
+
         for n in outneighbors(g, v)
             set_props!(g, v, n, lasteoutprops[n])
         end

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -435,6 +435,12 @@ import Base64:
     @test get_prop(mga, 5, :prop) == "node5"
     @test get_prop(mga, 1, :prop) == "newnode1"
 
+    # test for 87
+    mdg = MetaDiGraph(2)
+    add_edge!(mdg, 2, 2)
+    rem_vertex!(mdg, 1)
+    @test neighbors(mdg, 1) == [1]
+    @test nv(mdg) == 1
 
 end
 


### PR DESCRIPTION
Resolves an issue where properties that point from the last node to the last node don't get updated with the new vertex number, referenced in #87 

The current version of MetaGraphs.jl fails with the following example:

```julia
using LightGraphs, MetaGraphs
g = MetaDiGraph(2)
add_edge!(g, 2, 2)
rem_vertex!(g, 1)
```

Yields

```
ERROR: LoadError: KeyError: key 1 not found
Stacktrace:
 [1] getindex
   @ ./dict.jl:482 [inlined]
 [2] rem_vertex!(g::MetaDiGraph{Int64, Float64}, v::Int64)
   @ MetaGraphs ~/.julia/packages/MetaGraphs/UlMik/src/MetaGraphs.jl:184
```